### PR TITLE
do a k8s patch instead of apply

### DIFF
--- a/tasks/cleanup.yml
+++ b/tasks/cleanup.yml
@@ -5,7 +5,7 @@
   set_fact:
     _owner_references: "{{ item.metadata.ownerReferences | default([]) + owner_references | unique | list }}"
 
-- name: remove custom resource owner refernce if there is at least 1 other owner reference
+- name: remove custom resource owner reference if there is at least 1 other owner reference
   set_fact:
     _owner_references: "{{ _owner_references | rejectattr('name', 'equalto', ansible_operator_meta.name) | list }}"
   when:  _owner_references | length > 1
@@ -17,10 +17,11 @@
     update:
       ownerReferences: "{{ _owner_references }}"
 
-- name: "reapply {{ item.metadata.name }} with new ownerreferences"
+- name: "patch {{ item.metadata.name }} with new ownerreferences"
   k8s:
-    apply: true
     definition: "{{ item | combine(update) }}"
+    merge_type:
+      - json
   vars:
     update:
       metadata: "{{ metadata }}"


### PR DESCRIPTION
# Omschrijving

cleanup applied k8s resources niet meer, maar doet een patch. hierdoor wordt niet de last-applied annotatie alsnog toegevoegd aan configmaps

https://dev.kadaster.nl/jira/browse/PDOK-13468

## Type verandering

(Verwijder de opties die niet relevant zijn.)

- Verbetering oude feature

# Checklist:

- [x] Ik heb de code in deze PR zelf nogmaals nagekeken
- [x] Ik heb mijn code beter achtergelaten dan dat ik het aantrof
- [x] De code is leesbaar en de moeilijke onderdelen zijn voorzien van commentaar
- [ ] Ik heb de tests toegevoegd/uitgebreid indien nodig
- [x] Ik heb de tests gedraaid die de werking van mijn wijziging bewijst
- [ ] De [PDOK documentatie](https://github.com/PDOK/interne-documentatie) is bijgewerkt indien nodig.
- [x] Er zit geen gevoelig informatie in deze PR (wachtwoorden etc)