### PR TITLE
fixed maintain existing owner references

### DIFF
--- a/tasks/cleanup.yml
+++ b/tasks/cleanup.yml
@@ -1,27 +1,34 @@
 ---
 # tasks file for cleanup
-
 - name: combine existing ownerRefences with new ownerReferences
   set_fact:
-    _owner_references: "{{ item.metadata.ownerReferences | default([]) + owner_references | unique | list }}"
+    _owner_references: "{{ item.metadata.ownerReferences | default([]) + (cluster_resources.resources[0].metadata.ownerReferences | default([]) ) + owner_references | unique | list }}"
+
+# awaiting https://docs.ansible.com/ansible/latest/collections/kubernetes/core/k8s_json_patch_module.html (kubernetes.core 2.0.0) for better patching of ownerreferences
+# for now already applied resources must be retrieved from the cluster
+- name: get applied resource
+  k8s_info:
+    api_version: "{{ item.apiVersion }}"
+    kind: "{{ item.kind }}"
+    namespace: "{{ ansible_operator_meta.namespace }}"
+    name: "{{ item.metadata.name }}"
+  register: cluster_resources
+
+- name: combine cluster ownerRefences with ownerReferences
+  set_fact:
+    _owner_references: "{{ cluster_resources.resources[0].metadata.ownerReferences | default([]) + _owner_references | unique | list }}"
 
 - name: remove custom resource owner reference if there is at least 1 other owner reference
   set_fact:
     _owner_references: "{{ _owner_references | rejectattr('name', 'equalto', ansible_operator_meta.name) | list }}"
   when:  _owner_references | length > 1
 
-- name: add ownerRefence to existing metadata
-  set_fact:
-    metadata: "{{ item.metadata | combine(update) }}"
-  vars:
-    update:
-      ownerReferences: "{{ _owner_references }}"
-
 - name: "patch {{ item.metadata.name }} with new ownerreferences"
   k8s:
-    definition: "{{ item | combine(update) }}"
+    definition: "{{ item | combine(update, recursive=true) }}"
     merge_type:
-      - json
+      - merge
   vars:
     update:
-      metadata: "{{ metadata }}"
+      metadata:
+        ownerReferences: "{{ _owner_references }}"

--- a/tasks/cleanup.yml
+++ b/tasks/cleanup.yml
@@ -2,7 +2,7 @@
 # tasks file for cleanup
 - name: combine existing ownerRefences with new ownerReferences
   set_fact:
-    _owner_references: "{{ item.metadata.ownerReferences | default([]) + (cluster_resources.resources[0].metadata.ownerReferences | default([]) ) + owner_references | unique | list }}"
+    _owner_references: "{{ item.metadata.ownerReferences | default([]) + owner_references | unique | list }}"
 
 # awaiting https://docs.ansible.com/ansible/latest/collections/kubernetes/core/k8s_json_patch_module.html (kubernetes.core 2.0.0) for better patching of ownerreferences
 # for now already applied resources must be retrieved from the cluster

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,15 +26,17 @@
       name: "{{ item.metadata.name }}"
       uid: "{{ item.metadata.uid }}"
   loop: "{{ replicasets.resources }}"
+  loop_control:
+    label: "{{ item.metadata.name }}"
   when: replicasets.resources | length > 0
 
 - name: set owner_references to custom resource when no replicasets where found
   set_fact:
     owner_references:
-    - apiVersion: "{{ resource.apiVersion }}"
-      kind: "{{ resource.kind }}"
-      name: "{{ resource.metadata.name }}"
-      uid: "{{ resource.metadata.uid }}"
+      - apiVersion: "{{ resource.apiVersion }}"
+        kind: "{{ resource.kind }}"
+        name: "{{ resource.metadata.name }}"
+        uid: "{{ resource.metadata.uid }}"
   when: replicasets.resources | length == 0
 
 - include_tasks: cleanup.yml


### PR DESCRIPTION
# Omschrijving

Aanpassingen
- Owner references worden na herbepalen gepatched op betreffende resource
- Reeds bestaande ownerreferences op de resource in het cluster blijven behouden 

https://dev.kadaster.nl/jira/browse/PDOK-13468

## Type verandering

(Verwijder de opties die niet relevant zijn.)

- Verbetering oude feature

# Checklist:

- [x] Ik heb de code in deze PR zelf nogmaals nagekeken
- [x] Ik heb mijn code beter achtergelaten dan dat ik het aantrof
- [x] De code is leesbaar en de moeilijke onderdelen zijn voorzien van commentaar
- [ ] Ik heb de tests toegevoegd/uitgebreid indien nodig
- [x] Ik heb de tests gedraaid die de werking van mijn wijziging bewijst
- [x] De [PDOK documentatie](https://github.com/PDOK/interne-documentatie) is bijgewerkt indien nodig.
- [x] Er zit geen gevoelig informatie in deze PR (wachtwoorden etc)